### PR TITLE
Add proxy for api.imgur.com, i.imgur.com, and imgur.com

### DIFF
--- a/conf.d/twilio.conf
+++ b/conf.d/twilio.conf
@@ -5,4 +5,16 @@ server {
   location /api.twilio.com/ {
     proxy_pass https://api.twilio.com/;
   }
+
+  location /api.imgur.com/ {
+    proxy_pass https://api.imgur.com/;
+  }
+
+  location /i.imgur.com/ {
+    proxy_pass https://i.imgur.com/;
+  }
+
+  location /imgur.com/ {
+    proxy_pass https://imgur.com/;
+  }
 }


### PR DESCRIPTION
Create this pull request in favor of #1.
